### PR TITLE
Unsetting Single-value and Multi-value Properties

### DIFF
--- a/lib/cmis.js
+++ b/lib/cmis.js
@@ -1318,13 +1318,15 @@
             for (var id in properties){
                 options['propertyId['+i+']'] = id;
                 var propertyValue = properties[id];
-                if (toString.apply(propertyValue) == '[object Array]') {
-                    for (var j=0;j<propertyValue.length;j++) {
-                        options['propertyValue['+i+']['+j+']'] = propertyValue[j];
+                if (propertyValue !== null && propertyValue !== undefined) {
+                    if (toString.apply(propertyValue) == '[object Array]') {
+                        for (var j=0;j<propertyValue.length;j++) {
+                            options['propertyValue['+i+']['+j+']'] = propertyValue[j];
+                        }
                     }
-                }
-                else {
-                    options['propertyValue['+i+']'] = propertyValue;
+                    else {
+                        options['propertyValue['+i+']'] = propertyValue;
+                    }
                 }
                 i++;
             }


### PR DESCRIPTION
5.4.4.3.11 Single-value Properties
[...] To unset the property, the client must submit form data in which the propertyId MUST be present and the propertyValue control MUST NOT be present.

5.4.4.3.12 Multi-value Properties
[...] To unset the property, NO propertyValue control MUST be present.
