### PR TITLE
changeToken in setContentStream + 'returnVersion' argument

### DIFF
--- a/lib/cmis.js
+++ b/lib/cmis.js
@@ -113,8 +113,8 @@
             options = _fill(options);
             options.cmisselector = 'object';
             options.objectId = objectId;
-            if (returnVersion && returnVersion != 'this') {
-                options.major = (returnVersion == 'latestmajor');
+            if (returnVersion == 'latestmajor' || returnVersion == 'latest') {
+                options.returnVersion = returnVersion;
             }
             return new CmisRequest(_get(session.defaultRepository.rootFolderUrl)
                 .query(options));
@@ -686,8 +686,8 @@
             options = _fill(options);
             options.cmisselector = 'properties';
             options.objectId = objectId;
-            if (returnVersion && returnVersion != 'this') {
-                options.major = (returnVersion == 'latestmajor');
+            if (returnVersion == 'latestmajor' || returnVersion == 'latest') {
+                options.returnVersion = returnVersion;
             }
             return new CmisRequest(_get(session.defaultRepository.rootFolderUrl)
                 .query(options));                      


### PR DESCRIPTION
The "changeToken" parameter was not used in the function body. It should be passed via the "options" parameter (like in other methods).

For the selectors "object" and "properties", the argument is 'returnVersion' and not 'major'.
