### PR TITLE
Property case correction

### DIFF
--- a/lib/cmis.js
+++ b/lib/cmis.js
@@ -972,7 +972,7 @@
       }
       var properties = input || {};
       if (comment) {
-        options.checkInComment = comment;
+        options.checkinComment = comment;
       }
       options.major = !!major
       options.objectId = objectId;


### PR DESCRIPTION
Hi,
According to the CMIS specification, the correct typo is : checkinComment
Cf : http://docs.oasis-open.org/cmis/CMIS/v1.1/os/CMIS-v1.1-os.html

Thank you for your job, it's a great library !
Wiser.
