### PR TITLE
Removed reference to a nonexistent 'policyID' argument to applyACL to co...

### DIFF
--- a/lib/cmis.js
+++ b/lib/cmis.js
@@ -1071,7 +1071,6 @@
         session.applyACL = function (objectId, addACEs, removeACEs, propagation) {
             var options = _fill(options);
             options.objectId = objectId;
-            options.policyId = policyId;
             options.cmisaction = 'applyACL';
             _setACEs(addACEs,'add', options);
             _setACEs(removeACEs,'remove', options);


### PR DESCRIPTION
...rrect error.

I noticed `applyACL` was throwing an error by referencing a nonexistent `policyId` argument. I deleted the line in question and it seems to be working now. I wasn't sure about submitting this as a PR without a test, but I didn't immediately see an existing test, or a good way to mock the backend without significant additional code.

Nevertheless, I hope this helps!