### PR TITLE
bugfix character case on searchAllVersions parameter of query service

### DIFF
--- a/lib/cmis.js
+++ b/lib/cmis.js
@@ -79,7 +79,7 @@
       return session;
     };
 
-    /**  
+    /**
      * Connects to a cmis server and retrieves repositories,
      * token or credentils must already be set
      *
@@ -500,15 +500,15 @@
     /**
      * performs a cmis query against the repository
      * @param {String} statement
-     * @param {Boolean} searchAllversions
+     * @param {Boolean} searchAllVersions
      * @param {Object} options (possible options: maxItems, skipCount, orderBy, renditionFilter, includeAllowableActions, includeRelationships, succinct, token)
      * @return {CmisRequest}
      */
-    session.query = function (statement, searchAllversions, options) {
+    session.query = function (statement, searchAllVersions, options) {
       options = _fill(options);
       options.cmisaction = 'query';
       options.statement = statement;
-      options.searchAllversions = !!searchAllversions;
+      options.searchAllVersions = !!searchAllVersions;
       return new CmisRequest(_post(session.defaultRepository.repositoryUrl)
         .send(options));
 
@@ -1120,7 +1120,7 @@
     // http://visionmedia.github.io/superagent
     var request;
 
-    // if running on node.js require superagent 
+    // if running on node.js require superagent
     if (typeof module !== 'undefined' && module.exports) {
       request = require('superagent');
     } else {


### PR DESCRIPTION
According to CMIS documentation, the "query" service accepts a parameter "searchAllVersions". There was a case mismatch in this library.