### PR TITLE
Change parameter name for getAllVersions call

### DIFF
--- a/lib/cmis.js
+++ b/lib/cmis.js
@@ -998,13 +998,13 @@
 
     /**
      * gets versions of object
-     * @param {String} objectId
+     * @param {String} versionSeriesId
      * @param {Object} options (possible options: filter, includeAllowableActions, succinct, token)
      * @return {CmisRequest}
      */
-    session.getAllVersions = function (objectId, options) {
+    session.getAllVersions = function (versionSeriesId, options) {
       var options = _fill(options);
-      options.objectId = objectId;
+      options.versionSeriesId = versionSeriesId;
       options.cmisselector = 'versions';
       return new CmisRequest(_get(session.defaultRepository.rootFolderUrl)
         .query(options));


### PR DESCRIPTION
Hi,
It's me again ;)

According to the specification (http://docs.oasis-open.org/cmis/CMIS/v1.1/os/CMIS-v1.1-os.html#x1-3440006) the getAllVersions service has 2 required parameters : repositoryId and versionSeriesId.
So I made and propose to you this little change (before the parameter was objectId).

BR.
Wiser.