### PR TITLE
Allow to specify the charset used for non-file fields posted int mult…

### DIFF
--- a/lib/cmis.js
+++ b/lib/cmis.js
@@ -88,6 +88,17 @@
     };
 
     /**
+     * sets character set used for non file fields in posted
+     * multipart/form-data resource
+     * @param {string} characterSet
+     * @return {CmisSession}
+     */
+    session.setCharacterSet = function (characterSet) {
+      _characterSet = characterSet;
+      return session;
+    };
+
+    /**
      * Connects to a cmis server and retrieves repositories,
      * token or credentils must already be set
      *
@@ -1280,6 +1291,7 @@
     var _token = null;
     var _username = null;
     var _password = null;
+    var _characterSet;
     var _afterlogin;
 
     var _proxyUrl = null;
@@ -1325,6 +1337,12 @@
 
     var _postMultipart = function(url, options, content, mimeTypeExtension, filename) {
       var req = _http('POST', url);
+      if (_characterSet !== undefined && options.length > 0){
+        // IN HTML5, the character set to use for non-file fields can
+        // be specified in a multipart by using a __charset__ field.
+        // https://dev.w3.org/html5/spec-preview/attributes-common-to-form-controls.html#attr-fe-name-charset
+        req.field('_charset_', _characterSet);
+      }
       filename = filename || 'undefined';
       for (var k in options) {
         if (options[k] == 'cmis:name') {


### PR DESCRIPTION
…ipart/form-data

If you post a file with properties to update into the same multipart/form-data, you must be able to specify the charset used for your non-file fields to avoid a wrong decoding by the server. The HTML specs specifies the use of a pseudo field '_charset_' to do it (https://dev.w3.org/html5/spec-preview/attributes-common-to-form-controls.html#attr-fe-name-charset). If the library is used into a browser, you can specify the charset by calling the new method 'setCharacterSet' on the session object (ie: mySession.setCharacterSet(document.characterSet);)