### PR TITLE
Fix case where cfg.headers was not defined

### DIFF
--- a/src/cmis.ts
+++ b/src/cmis.ts
@@ -249,11 +249,9 @@ export namespace cmis {
         auth = `Bearer ${this.token}`;
       }
 
-      let cfg: RequestInit = { method: method };
+      let cfg: RequestInit = { method: method, headers: {} };
       if (auth) {
-        cfg.headers = {
-          'Authorization': auth
-        };
+        cfg.headers['Content-Type'] = auth;
       } else {
         cfg.credentials = 'include';
       }


### PR DESCRIPTION
When auth was undefined, cfg.headers was never initialized, so cfg.headers['Content-Type'] on line 290 failed