### PR TITLE
Remove redundant optional key from createDocument definition

### DIFF
--- a/src/cmis.ts
+++ b/src/cmis.ts
@@ -793,7 +793,7 @@ export namespace cmis {
     public createDocument(
       parentId: string,
       content: string | Blob | Buffer,
-      input: string | { 'cmis:name': string, 'cmis:objectTypeId'?: string, [k: string]: string | string[] | number | number[] | Date | Date[] },
+      input: string | { 'cmis:name': string, [k: string]: string | string[] | number | number[] | Date | Date[] },
       mimeTypeExtension?: string,
       versioningState?: 'none' | 'major' | 'minor' | 'checkedout',
       policies?: string[],


### PR DESCRIPTION
The 'cmis:objectTypeId' key is redundant and creates a TS2411 typescript error when compiling.
Here someone reported a similar error, and there you can see the answer https://github.com/Microsoft/TypeScript/issues/10042

Basically, its redundant because its covered by the later [k: string] index definition